### PR TITLE
add .gitignore and NumberKit.playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,63 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+
+## Other
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the 
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://github.com/fastlane/fastlane/blob/master/docs/Gitignore.md
+
+fastlane/report.xml
+fastlane/screenshots

--- a/NumberKit.playground/Pages/BigInt.xcplaygroundpage/Contents.swift
+++ b/NumberKit.playground/Pages/BigInt.xcplaygroundpage/Contents.swift
@@ -1,0 +1,5 @@
+//: [Previous](@previous)
+
+BigInt(2) ** 1024
+
+//: [Next](@next)

--- a/NumberKit.playground/Pages/Complex.xcplaygroundpage/Contents.swift
+++ b/NumberKit.playground/Pages/Complex.xcplaygroundpage/Contents.swift
@@ -1,0 +1,9 @@
+//: [Previous](@previous)
+
+import Foundation
+
+sqrt(-1.0+0.0.i)
+exp(M_PI.i)
+log(-1.0+0.0.i)
+
+//: [Next](@next)

--- a/NumberKit.playground/Pages/Rational.xcplaygroundpage/Contents.swift
+++ b/NumberKit.playground/Pages/Rational.xcplaygroundpage/Contents.swift
@@ -1,0 +1,16 @@
+//: [Previous](@previous)
+
+func bfact(n:Int)->BigInt {
+    return n < 2
+        ? BigInt(n)
+        : (2...n).reduce(BigInt(1)) { $0 * BigInt($1) }
+}
+
+Rational(2,-4)
+
+let r99 = Rational(bfact(99))
+let r_100 = Rational(BigInt(1), bfact(100))
+
+r99 * r_100
+
+//: [Next](@next)

--- a/NumberKit.playground/Sources/BigInt.swift
+++ b/NumberKit.playground/Sources/BigInt.swift
@@ -1,0 +1,1 @@
+../../NumberKit/BigInt.swift

--- a/NumberKit.playground/Sources/Complex.swift
+++ b/NumberKit.playground/Sources/Complex.swift
@@ -1,0 +1,1 @@
+../../NumberKit/Complex.swift

--- a/NumberKit.playground/Sources/NumberUtil.swift
+++ b/NumberKit.playground/Sources/NumberUtil.swift
@@ -1,0 +1,1 @@
+../../NumberKit/NumberUtil.swift

--- a/NumberKit.playground/Sources/Rational.swift
+++ b/NumberKit.playground/Sources/Rational.swift
@@ -1,0 +1,1 @@
+../../NumberKit/Rational.swift

--- a/NumberKit.playground/Sources/stub.swift
+++ b/NumberKit.playground/Sources/stub.swift
@@ -1,0 +1,3 @@
+// seems like you need this for playground to work properly
+import Foundation
+

--- a/NumberKit.playground/contents.xcplayground
+++ b/NumberKit.playground/contents.xcplayground
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='6.0' target-platform='ios'>
+    <pages>
+        <page name='BigInt'/>
+        <page name='Complex'/>
+        <page name='Rational'/>
+    </pages>
+</playground>


### PR DESCRIPTION
I thought it would be nice if this project comes along with playground with working samples.  Note files in `Sources` under the playground are symlinked.

I found your project when I was looking for a pure-swift implementation of BigNum.  What a surprise you also have Complex since I was working on my own.

https://github.com/dankogai/swift-complex
